### PR TITLE
Recipe.check_requirements fix

### DIFF
--- a/economy_collection/crafting.py
+++ b/economy_collection/crafting.py
@@ -91,13 +91,15 @@ class Recipe:
         
         lowest_ns = []
         for itemname in self.requirements:
-            if itemname in inventory:
+            if itemname not in inventory:
+                have_n = 0
+            else:
                 have_n = inventory[itemname]["amount"]
-                lowest = have_n.__floordir__(self.requirements[itemname])
-                lowest_ns.append(lowest)
-        
+            lowest = have_n // self.requirements[itemname]
+            lowest_ns.append(lowest)
+
         lowest = min(lowest_ns)
-        
+
         return lowest
 
 class Workplace:


### PR DESCRIPTION
Code assumed that if a resource is not present in the inventory, it can be safely ignored. Obviously it should just work with there being zero units of this resource.